### PR TITLE
/images: lazy load images

### DIFF
--- a/templates/images.html
+++ b/templates/images.html
@@ -25,7 +25,7 @@
 <table style="text-align: center; width: 100%">
 <tr>
 {% for img in images[:200] -%}
-<td><img src="//upload.wikimedia.org/wikipedia/commons/thumb/{{ img[1][0] }}/{{ img[1] }}/{{ img[0] }}/{{ img[2] >= img[3] and 250 or (img[2] / img[3] * 250)|int }}px-{{ img[0] }}"/>
+<td><img loading="lazy" src="//upload.wikimedia.org/wikipedia/commons/thumb/{{ img[1][0] }}/{{ img[1] }}/{{ img[0] }}/{{ img[2] >= img[3] and 250 or (img[2] / img[3] * 250)|int }}px-{{ img[0] }}"/>
     <br/><a href="https://commons.wikimedia.org/wiki/File:{{ img[0] }}">{{ img[0]|replace('_', ' ') }}</a></td>
 {%- if loop.index % 4 == 0 %}
 </tr>


### PR DESCRIPTION
Without lazy loading the images, the browser will try to load all of the potential 200 images at once. If there is a lot of images on the page this will trigger Wikimedia's rate limit causing some images to not render.

loading="lazy"  will ensure that images are loaded as the user scrolls rather than all at once.

Example of the issue being triggered:

![Screenshot 2024-09-30 at 11-48-46 Images of Bysmon in Wiki Loves Monuments 2024 in Sweden](https://github.com/user-attachments/assets/ad275055-6db1-44d2-aac2-86bcb08c4c44)