### PR TITLE
Add REST API

### DIFF
--- a/api.py
+++ b/api.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8  -*-
+
+from flask import Blueprint, jsonify
+import data_store
+from functions import normalize_country_name
+
+api = Blueprint("api", __name__)
+
+
+@api.route("/api/events")
+def events():
+    data_store.loadDB()
+    if not data_store.events_data:
+        return jsonify({"error": "Database not loaded"}), 503
+    return jsonify(data_store.events_data)
+
+
+@api.route("/api/events/<slug>")
+def event(slug):
+    data_store.loadDB()
+    if not data_store.db:
+        return jsonify({"error": "Database not loaded"}), 503
+    
+    if slug in data_store.db:
+        return jsonify(data_store.db[slug])
+    else:
+        return jsonify({"error": "Event not found"}), 404
+
+
+@api.route("/api/country/<name>")
+def country(name):
+    data_store.loadDB()
+    if not data_store.country_data:
+        return jsonify({"error": "Database not loaded"}), 503
+    
+    name = normalize_country_name(name)
+    if name in data_store.country_data:
+        return jsonify(data_store.country_data[name])
+    else:
+        return jsonify({"error": "Country not found"}), 404

--- a/data_store.py
+++ b/data_store.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8  -*-
+
+import json
+from os.path import getmtime
+
+from functions import (
+    get_country_data,
+    get_event_name,
+    get_events_data,
+    get_menu,
+)
+
+db = None
+menu = None
+events_data = None
+events_names = None
+country_data = None
+dbtime = None
+
+
+def loadDB():
+    global db, menu, events_data, events_names, country_data, dbtime
+    try:
+        mtime = getmtime("db.json")
+    except OSError:
+        mtime = None
+
+    if dbtime and dbtime == mtime:
+        return
+    dbtime = mtime
+    try:
+        with open("db.json", "r") as f:
+            db = json.load(f)
+    except IOError:
+        db = None
+    
+    if db:
+        menu = get_menu(db)
+        events_data = get_events_data(db)
+        events_names = {slug: get_event_name(slug) for slug in list(events_data.keys())}
+        country_data = get_country_data(db)
+    else:
+        menu = {}
+        events_data = {}
+        events_names = {}
+        country_data = {}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8  -*-
+import json
+import unittest
+import os
+import sys
+
+# Add parent directory to path to import app and other modules
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from app import app
+import data_store
+import functions
+
+class TestApi(unittest.TestCase):
+    def setUp(self):
+        self.app = app.test_client()
+        current_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        data_file = os.path.join(current_path, "conf/db.dump.json")
+        with open(data_file, "r") as f:
+            data_store.db = json.load(f)
+        
+        # Initialize other data structures in data_store
+        data_store.menu = functions.get_menu(data_store.db)
+        data_store.events_data = functions.get_events_data(data_store.db)
+        data_store.events_names = {slug: functions.get_event_name(slug) for slug in list(data_store.events_data.keys())}
+        data_store.country_data = functions.get_country_data(data_store.db)
+        
+        # Mock loadDB to do nothing
+        self.original_loadDB = data_store.loadDB
+        data_store.loadDB = lambda: None
+
+    def tearDown(self):
+        data_store.loadDB = self.original_loadDB
+
+    def test_events(self):
+        response = self.app.get("/api/events")
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data)
+        self.assertIn("monuments", data)
+        self.assertIn("earth", data)
+
+    def test_event(self):
+        response = self.app.get("/api/events/monuments2016")
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data)
+        self.assertIn("Panama", data)
+        self.assertIn("Turkey", data)
+
+    def test_event_not_found(self):
+        response = self.app.get("/api/events/invalid")
+        self.assertEqual(response.status_code, 404)
+
+    def test_country(self):
+        response = self.app.get("/api/country/Panama")
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data)
+        self.assertIn("monuments", data)
+
+    def test_country_not_found(self):
+        response = self.app.get("/api/country/InvalidCountry")
+        self.assertEqual(response.status_code, 404)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION

This PR adds a REST API.

**Changes**
- Extracted data loading logic from `app.py` into a new `data_store.py` module. This allows the database state to be shared between the main Flask app and the new API blueprint without circular imports.
- Created a new `api` blueprint in `api.py` with the following endpoints:
    - `GET /api/events`: List all available events.
    - `GET /api/events/<slug>`: Get detailed statistics for a specific event (e.g., `monuments2016`).
    - `GET /api/country/<name>`: Get statistics for a specific country.